### PR TITLE
[Chore] Add 'server_tokens off' so nginx doesn't share its version

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -14,6 +14,7 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
   root /data/www/;
+  server_tokens off;
 
   include {{nginx_conf_dir}}/mime.types;
   default_type application/octet-stream;


### PR DESCRIPTION
Http section didn't have 'server_tokens off', fix tested on integration server:

**`curl -I https://app.simplifield.com`:**
```
HTTP/2 200 
server: nginx/1.15.8
date: Mon, 03 Jun 2019 12:35:20 GMT
content-type: text/html
....
```

**`curl -I https://sandbox-boston.simplifield.qa`:**
```
HTTP/2 200 
server: nginx
date: Mon, 03 Jun 2019 12:34:09 GMT
content-type: text/html
....
```